### PR TITLE
Update 5 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Utilities.ICalParser.nuspec
+++ b/MakoIoT.Device.Utilities.ICalParser.nuspec
@@ -17,10 +17,10 @@
     <description>This package includes the minimal iCalendar parser (VEVENT only) for .NET nanoFramework C# projects.</description>
     <tags>nanoFramework C# csharp netmf netnf ical</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.62" />
-      <dependency id="nanoFramework.System.Text" version="1.3.29" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.89" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.63" />
+      <dependency id="nanoFramework.System.Text" version="1.3.36" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.91" />
     </dependencies>
   </metadata>
   <files>

--- a/Tests/MakoIoT.Device.Utilities.ICalParser.Test/MakoIoT.Device.Utilities.ICalParser.Test.nfproj
+++ b/Tests/MakoIoT.Device.Utilities.ICalParser.Test/MakoIoT.Device.Utilities.ICalParser.Test.nfproj
@@ -33,20 +33,20 @@
     <ProjectReference Include="..\..\src\MakoIoT.Device.Utilities.ICalParser\MakoIoT.Device.Utilities.ICalParser.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.68.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.68\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.69.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.69\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.68\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.69\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.89.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.89\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.91\lib\System.IO.Streams.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -55,7 +55,7 @@
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <!-- MANUAL UPDATE HERE -->
-  <Import Project="..\packages\nanoFramework.TestFramework.3.0.68\build\nanoFramework.TestFramework.targets" Condition="Exists('..\packages\nanoFramework.TestFramework.3.0.68\build\nanoFramework.TestFramework.targets')" />
+  <Import Project="..\packages\nanoFramework.TestFramework.3.0.69\build\nanoFramework.TestFramework.targets" Condition="Exists('..\packages\nanoFramework.TestFramework.3.0.69\build\nanoFramework.TestFramework.targets')" />
   <ProjectExtensions>
     <ProjectCapabilities>
       <ProjectConfigurationsDeclaredAsItems />
@@ -65,6 +65,6 @@
     <PropertyGroup>
       <WarningText>Update the Import path in nfproj to the correct nanoFramework.TestFramework NuGet package folder.</WarningText>
     </PropertyGroup>
-    <Warning Condition="!Exists('..\packages\nanoFramework.TestFramework.3.0.68\build\nanoFramework.TestFramework.targets')" Text="'$(WarningText)'" />
+    <Warning Condition="!Exists('..\packages\nanoFramework.TestFramework.3.0.69\build\nanoFramework.TestFramework.targets')" Text="'$(WarningText)'" />
   </Target>
 </Project>

--- a/Tests/MakoIoT.Device.Utilities.ICalParser.Test/packages.config
+++ b/Tests/MakoIoT.Device.Utilities.ICalParser.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.89" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.68" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
+  <package id="nanoFramework.TestFramework" version="3.0.69" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Utilities.ICalParser/MakoIoT.Device.Utilities.ICalParser.nfproj
+++ b/src/MakoIoT.Device.Utilities.ICalParser/MakoIoT.Device.Utilities.ICalParser.nfproj
@@ -24,17 +24,17 @@
     <Compile Include="Parser.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.62\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.63\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.89.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.89\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.91\lib\System.IO.Streams.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.Utilities.ICalParser/packages.config
+++ b/src/MakoIoT.Device.Utilities.ICalParser/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.89" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.17.1 to 1.17.7</br>Bumps nanoFramework.System.Collections from 1.5.62 to 1.5.63</br>Bumps nanoFramework.System.IO.Streams from 1.1.89 to 1.1.91</br>Bumps nanoFramework.System.Text from 1.3.29 to 1.3.36</br>Bumps nanoFramework.TestFramework from 3.0.68 to 3.0.69</br>
[version update]

### :warning: This is an automated update. :warning:
